### PR TITLE
hot.fix.hmr

### DIFF
--- a/src/app/states/layout.component.ts
+++ b/src/app/states/layout.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: '[id="layout"]',
+  selector: 'app-layout',
   templateUrl: './layout.html'
 })
 export class LayoutComponent implements OnInit {

--- a/src/index.html
+++ b/src/index.html
@@ -9,12 +9,14 @@
   <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
 </head>
 <body id="layout">
-<!-- preloader app initializing loading -->
-<div class="def-preloader">
-    <div id="SPW">
-        <div id="SP_1" class="sp"></div> <div id="SP_2" class="sp"></div> <div id="SP_3" class="sp"></div> <div id="SP_4" class="sp"></div>
-        <div id="SP_5" class="sp"></div> <div id="SP_6" class="sp"></div> <div id="SP_7" class="sp"></div> <div id="SP_8" class="sp"></div>
+<app-layout>
+    <!-- preloader app initializing loading -->
+    <div class="def-preloader">
+        <div id="SPW">
+            <div id="SP_1" class="sp"></div> <div id="SP_2" class="sp"></div> <div id="SP_3" class="sp"></div> <div id="SP_4" class="sp"></div>
+            <div id="SP_5" class="sp"></div> <div id="SP_6" class="sp"></div> <div id="SP_7" class="sp"></div> <div id="SP_8" class="sp"></div>
+        </div>
     </div>
-</div>
+</app-layout>
 </body>
 </html>


### PR DESCRIPTION
* fix "hot module replacement" behaviour, works fine only when bootstrap component selector is tag
